### PR TITLE
refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+target
+.idea

--- a/src/main/java/io/github/eocqrs/cmig/State.java
+++ b/src/main/java/io/github/eocqrs/cmig/State.java
@@ -22,10 +22,8 @@
 
 package io.github.eocqrs.cmig;
 
+import io.github.eocqrs.cmig.sha.StateChanges;
 import org.cactoos.Scalar;
-/*
- * @todo #32:30m/DEV design State interface
- */
 
 /**
  * State.
@@ -33,8 +31,8 @@ import org.cactoos.Scalar;
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.0.0
  */
-public interface State extends Scalar<String> {
-
+public interface State extends Scalar<StateChanges> {
   @Override
-  String value() throws Exception;
+  StateChanges value();
+
 }

--- a/src/main/java/io/github/eocqrs/cmig/State.java
+++ b/src/main/java/io/github/eocqrs/cmig/State.java
@@ -32,6 +32,7 @@ import org.cactoos.Scalar;
  * @since 0.0.0
  */
 public interface State extends Scalar<StateChanges> {
+  // @todo #37:2hr/DEV Find several designs for States implementations
   @Override
   StateChanges value();
 

--- a/src/main/java/io/github/eocqrs/cmig/meta/Author.java
+++ b/src/main/java/io/github/eocqrs/cmig/meta/Author.java
@@ -24,7 +24,7 @@ package io.github.eocqrs.cmig.meta;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import org.cactoos.Scalar;
+import org.cactoos.Text;
 import org.cactoos.io.ResourceOf;
 
 /**
@@ -33,7 +33,7 @@ import org.cactoos.io.ResourceOf;
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.0.0
  */
-public final class Author implements Scalar<String> {
+public final class Author implements Text {
 
   /**
    * XML.
@@ -75,7 +75,7 @@ public final class Author implements Scalar<String> {
   }
 
   @Override
-  public String value() throws Exception {
+  public String asString() {
     return this.xml.xpath(
       "/states/changeState[@id='%s']/@author"
         .formatted(

--- a/src/main/java/io/github/eocqrs/cmig/meta/Names.java
+++ b/src/main/java/io/github/eocqrs/cmig/meta/Names.java
@@ -76,7 +76,7 @@ public final class Names implements XpathList {
   }
 
   @Override
-  public List<String> value() throws Exception {
+  public List<String> value() {
     return this.xml.xpath(
       "/states/changeState[@id='%s']/files/file/@path"
         .formatted(

--- a/src/main/java/io/github/eocqrs/cmig/meta/XpathList.java
+++ b/src/main/java/io/github/eocqrs/cmig/meta/XpathList.java
@@ -35,5 +35,5 @@ import java.util.List;
 public interface XpathList extends Scalar<List<String>> {
 
   @Override
-  List<String> value() throws Exception;
+  List<String> value();
 }

--- a/src/main/java/io/github/eocqrs/cmig/session/Cassandra.java
+++ b/src/main/java/io/github/eocqrs/cmig/session/Cassandra.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 public interface Cassandra extends Scalar<Session>, Closeable {
 
   @Override
-  Session value() throws Exception;
+  Session value();
 
   @Override
   void close() throws IOException;

--- a/src/main/java/io/github/eocqrs/cmig/session/Cql.java
+++ b/src/main/java/io/github/eocqrs/cmig/session/Cql.java
@@ -33,7 +33,6 @@ public interface Cql {
   /**
    * Apply Query.
    *
-   * @throws Exception if something went wrong.
    */
-  void apply() throws Exception;
+  void apply();
 }

--- a/src/main/java/io/github/eocqrs/cmig/session/InFile.java
+++ b/src/main/java/io/github/eocqrs/cmig/session/InFile.java
@@ -57,12 +57,12 @@ public final class InFile implements Cql {
   }
 
   @Override
-  public void apply() throws Exception {
+  public void apply() {
     this.cassandra.value()
       .execute(
         new TextOf(
           new ResourceOf(this.name)
-        ).asString()
+        ).toString()
       );
   }
 }

--- a/src/main/java/io/github/eocqrs/cmig/session/Simple.java
+++ b/src/main/java/io/github/eocqrs/cmig/session/Simple.java
@@ -25,8 +25,6 @@ package io.github.eocqrs.cmig.session;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 
-import java.io.IOException;
-
 /**
  * Simple Cassandra.
  *

--- a/src/main/java/io/github/eocqrs/cmig/session/Simple.java
+++ b/src/main/java/io/github/eocqrs/cmig/session/Simple.java
@@ -68,12 +68,12 @@ public final class Simple implements Cassandra {
   }
 
   @Override
-  public Session value() throws Exception {
+  public Session value() {
     return this.cluster.connect();
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     this.cluster.close();
   }
 }

--- a/src/main/java/io/github/eocqrs/cmig/sha/Sha.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/Sha.java
@@ -42,10 +42,12 @@ public final class Sha implements Text {
    * State ID.
    */
   private final String id;
+
   /**
    * Master file.
    */
   private final String master;
+
   /**
    * CMIG directory.
    */

--- a/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
@@ -23,10 +23,10 @@
 package io.github.eocqrs.cmig.sha;
 
 import io.github.eocqrs.cmig.meta.XpathList;
+import lombok.SneakyThrows;
 import org.cactoos.Scalar;
 import org.cactoos.io.ResourceOf;
-import org.cactoos.list.ListOf;
-import org.cactoos.text.TextOf;
+import ru.l3r8y.UnixizedOf;
 
 import java.util.List;
 
@@ -62,18 +62,27 @@ public final class StateChanges implements Scalar<List<String>> {
   public List<String> value() throws Exception {
     return this.list.value()
       .stream()
-      .map(
-        file -> new UnixizedOf(
-          new ResourceOf(
-            "%s/%s"
-              .formatted(
-                this.cmig,
-                file
-              )
+      .map(this::contentOf)
+      .toList();
+  }
+
+  /**
+   * @todo #37:30min/DEV Move to separate class
+   * Create class ContentOf with tests.
+   * This puzzle might be moved into unixized library.
+   */
+  @SneakyThrows
+  private String contentOf(final String file) {
+    return new UnixizedOf(
+      new ResourceOf(
+        "%s/%s"
+          .formatted(
+            this.cmig,
+            file
           )
-        )
-          .asText()
-          .toString()
-      ).toList();
+      )
+    )
+      .asText()
+      .asString();
   }
 }

--- a/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
@@ -25,7 +25,6 @@ package io.github.eocqrs.cmig.sha;
 import io.github.eocqrs.cmig.meta.XpathList;
 import org.cactoos.Scalar;
 import org.cactoos.io.ResourceOf;
-import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 
 import java.util.List;
@@ -42,6 +41,7 @@ public final class StateChanges implements Scalar<List<String>> {
    * XPATH lists.
    */
   private final XpathList list;
+
   /**
    * CMIG directory.
    */
@@ -60,21 +60,17 @@ public final class StateChanges implements Scalar<List<String>> {
 
   @Override
   public List<String> value() throws Exception {
-    final List<String> contents = new ListOf<>();
-    final List<String> files = this.list.value();
-    for (final String file : files) {
-      final String content =
-        new TextOf(
+    return this.list.value()
+      .stream()
+      .map(
+        file -> new TextOf(
           new ResourceOf(
-            "%s/%s"
-              .formatted(
-                this.cmig,
-                file
-              )
+            "%s/%s".formatted(
+              this.cmig,
+              file
+            )
           )
-        ).asString();
-      contents.add(content);
-    }
-    return contents;
+        ).toString()
+      ).toList();
   }
 }

--- a/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
@@ -66,7 +66,7 @@ public final class StateChanges implements Scalar<List<String>> {
       .toList();
   }
 
-  /**
+  /*
    * @todo #37:30min/DEV Move to separate class
    * Create class ContentOf with tests.
    * This puzzle might be moved into unixized library.

--- a/src/test/java/io/github/eocqrs/cmig/meta/AuthorTest.java
+++ b/src/test/java/io/github/eocqrs/cmig/meta/AuthorTest.java
@@ -41,7 +41,7 @@ final class AuthorTest {
       new Author(
         "cmig/master.xml",
         "1"
-      ).value(),
+      ).asString(),
       new IsEqual<>(
         "test"
       )

--- a/src/test/java/it/CassandraIntegration.java
+++ b/src/test/java/it/CassandraIntegration.java
@@ -22,7 +22,7 @@
 
 package it;
 
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.CassandraContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -49,7 +49,7 @@ public abstract class CassandraIntegration {
       CassandraIntegration.CASSANDRA.getHost();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     CassandraIntegration.CASSANDRA.stop();
   }

--- a/src/test/java/it/CassandraIntegration.java
+++ b/src/test/java/it/CassandraIntegration.java
@@ -40,12 +40,12 @@ public abstract class CassandraIntegration {
     new CassandraContainer<>(
       DockerImageName.parse("cassandra:3.11.15")
     ).withExposedPorts(9042);
-  protected static String host;
+  protected static String HOST;
 
   @BeforeAll
   static void beforeAll() {
     CassandraIntegration.CASSANDRA.start();
-    CassandraIntegration.host =
+    CassandraIntegration.HOST =
       CassandraIntegration.CASSANDRA.getHost();
   }
 

--- a/src/test/java/it/CassandraRunsIT.java
+++ b/src/test/java/it/CassandraRunsIT.java
@@ -39,7 +39,7 @@ final class CassandraRunsIT extends CassandraIntegration {
   void runs() {
     MatcherAssert.assertThat(
       "Cassandra runs",
-      CASSANDRA.isRunning(),
+      CassandraIntegration.CASSANDRA.isRunning(),
       new IsEqual<>(true)
     );
   }

--- a/src/test/java/it/InFileIT.java
+++ b/src/test/java/it/InFileIT.java
@@ -41,8 +41,8 @@ final class InFileIT extends CassandraIntegration {
       () ->
         new InFile(
           new Simple(
-            CassandraIntegration.host,
-            CASSANDRA.getMappedPort(9042)
+            CassandraIntegration.HOST,
+            CassandraIntegration.CASSANDRA.getMappedPort(9042)
           ),
           "cmig/001-initial-keyspace.cql"
         ).apply(),

--- a/src/test/java/it/SimpleIT.java
+++ b/src/test/java/it/SimpleIT.java
@@ -39,7 +39,7 @@ final class SimpleIT extends CassandraIntegration {
   @Test
   void connectsSession() throws Exception {
     final Session session = new Simple(
-      CassandraIntegration.host,
+      CassandraIntegration.HOST,
       CASSANDRA.getMappedPort(9042)
     ).value();
     MatcherAssert.assertThat(

--- a/src/test/java/it/SimpleIT.java
+++ b/src/test/java/it/SimpleIT.java
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.Test;
 final class SimpleIT extends CassandraIntegration {
 
   @Test
-  void connectsSession() throws Exception {
+  void connectsSession() {
     final Session session = new Simple(
       CassandraIntegration.HOST,
-      CASSANDRA.getMappedPort(9042)
+      CassandraIntegration.CASSANDRA.getMappedPort(9042)
     ).value();
     MatcherAssert.assertThat(
       "Session is not null",


### PR DESCRIPTION
@h1alexbel take a look, please

wdyt?

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on making various changes and improvements to the codebase.

### Detailed summary:
- Added `target` and `.idea` to `.gitignore`.
- Updated `AuthorTest.java` to use `asString()` instead of `value()`.
- Updated `XpathList.java` to remove `throws Exception` from `value()`.
- Updated `Sha.java` to remove `throws Exception` from `value()` and `close()`.
- Updated `Cql.java` to remove `throws Exception` from `apply()`.
- Updated `CassandraRunsIT.java` to use `CassandraIntegration.CASSANDRA` instead of `CASSANDRA`.
- Updated `Names.java` to remove `throws Exception` from `value()`.
- Updated `InFile.java` to remove `throws Exception` from `apply()` and convert `asString()` to `toString()`.
- Updated `InFileIT.java` to use `CassandraIntegration.HOST` instead of `CassandraIntegration.host`.
- Updated `SimpleIT.java` to use `CassandraIntegration.HOST` instead of `CassandraIntegration.host`.
- Updated `Simple.java` to remove `throws IOException` from `close()`.
- Added import for `io.github.eocqrs.cmig.sha.StateChanges` in `State.java`.
- Updated `Author.java` to implement `Text` instead of `Scalar<String>`.
- Updated `CassandraIntegration.java` to use `@AfterAll` instead of `@AfterClass` and update variable name to `HOST`.
- Updated `StateChanges.java` to remove unused imports, refactor `value()` method, and add `contentOf()` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->