### PR TITLE
normalized

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -11,7 +11,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-12 ]
+        os: [ ubuntu-20.04, macos-12, windows-latest ]
         java: [ 17, 20 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -11,7 +11,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-12, windows-latest ]
+        os: [ ubuntu-20.04, macos-12, windows-2022 ]
         java: [ 17, 20 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@ SOFTWARE.
     <mockito-junit-jupiter.version>5.4.0</mockito-junit-jupiter.version>
     <hamcrest-all.version>1.3</hamcrest-all.version>
     <guava.version>19.0</guava.version>
+    <unixized.version>1.0.0</unixized.version>
   </properties>
   <dependencies>
     <dependency>
@@ -160,6 +161,11 @@ SOFTWARE.
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <version>${hamcrest-all.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ru.l3r8y</groupId>
+      <artifactId>unixized</artifactId>
+      <version>${unixized.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/src/main/java/io/github/eocqrs/cmig/sha/Sha.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/Sha.java
@@ -27,6 +27,7 @@ import org.cactoos.Text;
 import org.cactoos.bytes.Sha256DigestOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.text.HexOf;
+import org.cactoos.text.Normalized;
 
 import java.util.List;
 
@@ -79,7 +80,9 @@ public final class Sha implements Text {
     return new HexOf(
       new Sha256DigestOf(
         new InputOf(
-          contents.toString()
+          new Normalized(
+            contents.toString()
+          )
         )
       )
     ).asString();

--- a/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
@@ -26,8 +26,7 @@ import io.github.eocqrs.cmig.meta.XpathList;
 import org.cactoos.Scalar;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
-import org.cactoos.text.Normalized;
-import org.cactoos.text.TextOf;
+import ru.l3r8y.UnixizedOf;
 
 import java.util.List;
 
@@ -65,17 +64,17 @@ public final class StateChanges implements Scalar<List<String>> {
     final List<String> files = this.list.value();
     for (final String file : files) {
       final String content =
-        new Normalized(
-          new TextOf(
-            new ResourceOf(
-              "%s/%s"
-                .formatted(
-                  this.cmig,
-                  file
-                )
-            )
+        new UnixizedOf(
+          new ResourceOf(
+            "%s/%s"
+              .formatted(
+                this.cmig,
+                file
+              )
           )
-        ).asString();
+        )
+          .asText()
+          .asString();
       contents.add(content);
     }
     return contents;

--- a/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
@@ -26,6 +26,7 @@ import io.github.eocqrs.cmig.meta.XpathList;
 import org.cactoos.Scalar;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.Normalized;
 import org.cactoos.text.TextOf;
 
 import java.util.List;
@@ -64,13 +65,15 @@ public final class StateChanges implements Scalar<List<String>> {
     final List<String> files = this.list.value();
     for (final String file : files) {
       final String content =
-        new TextOf(
-          new ResourceOf(
-            "%s/%s"
-              .formatted(
-                this.cmig,
-                file
-              )
+        new Normalized(
+          new TextOf(
+            new ResourceOf(
+              "%s/%s"
+                .formatted(
+                  this.cmig,
+                  file
+                )
+            )
           )
         ).asString();
       contents.add(content);

--- a/src/test/java/io/github/eocqrs/cmig/sha/ShaTest.java
+++ b/src/test/java/io/github/eocqrs/cmig/sha/ShaTest.java
@@ -44,7 +44,7 @@ final class ShaTest {
         "cmig"
       ).asString(),
       new IsEqual<>(
-        "bb2e7331978b0457bcb9f64843e6d4f70ec6a517bffc1366832faed0bdc3bb87"
+        "97a046e3a06e2d406578175934c300dffbb13ee80db254874c7d19dc4bdd6832"
       )
     );
   }


### PR DESCRIPTION
closes #43 

@h1alexbel take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Windows and Java 20, updates dependencies, and introduces Unixized library for normalized file content.
### Detailed summary
- Added support for Windows and Java 20 in the Maven workflow
- Updated dependencies: added `unixized` library
- Modified `ShaTest.java`: updated expected hash value
- Modified `Sha.java`: added normalization of file content using `Normalized` class
- Modified `pom.xml`: added `unixized` dependency, updated versions of `hamcrest-all` and `guava`
- Modified `StateChanges.java`: replaced `TextOf` with `UnixizedOf` for file content normalization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->