### PR TITLE
rultor skip its

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -8,7 +8,7 @@ assets:
   pubring.gpg: eo-cqrs/eo-cqrs-secrets#assets/pubring.gpg
 merge:
   script:
-    - "mvn clean install --errors --batch-mode"
+    - "mvn clean install -DskipITs --errors --batch-mode"
 release:
   pre: false
   sensetive:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR focuses on updating the Maven command in the `.rultor.yml` file to skip integration tests during the clean install process.

Notable changes:
- Updated the `mvn clean install` command to include the `-DskipITs` flag

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->