### PR TITLE
back jacoco limits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,31 +262,30 @@ SOFTWARE.
                 <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <!-- @todo #1:15m/DEV back limits to 0.65, 0.61, 0.55, 0.55 -->
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.30</minimum>
+                      <minimum>0.65</minimum>
                     </limit>
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.30</minimum>
+                      <minimum>0.61</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.30</minimum>
+                      <minimum>0.55</minimum>
                     </limit>
                     <limit>
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.30</minimum>
+                      <minimum>0.55</minimum>
                     </limit>
                     <limit>
                       <counter>METHOD</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.30</minimum>
+                      <minimum>0.51</minimum>
                     </limit>
                     <limit>
                       <counter>CLASS</counter>


### PR DESCRIPTION
closes #23 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Update coverage limits in the `pom.xml` file.

### Detailed summary:
- Updated the minimum coverage limit for the `INSTRUCTION` counter from 0.30 to 0.65.
- Updated the minimum coverage limit for the `LINE` counter from 0.30 to 0.61.
- Updated the minimum coverage limit for the `BRANCH` counter from 0.30 to 0.55.
- Updated the minimum coverage limit for the `COMPLEXITY` counter from 0.30 to 0.55.
- Updated the minimum coverage limit for the `METHOD` counter from 0.30 to 0.51.
- No other notable changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->