### PR TITLE
ids

### DIFF
--- a/src/main/java/io/github/eocqrs/cmig/meta/Ids.java
+++ b/src/main/java/io/github/eocqrs/cmig/meta/Ids.java
@@ -23,18 +23,13 @@
 package io.github.eocqrs.cmig.meta;
 
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
-import org.cactoos.io.ResourceOf;
 
 import java.util.List;
 
 /**
- * File names of State.
- *
- * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * Ids of changeStates.
  */
-public final class Names implements XpathList {
+public final class Ids implements XpathList {
 
   /**
    * XML.
@@ -42,47 +37,18 @@ public final class Names implements XpathList {
   private final XML xml;
 
   /**
-   * State ID.
-   */
-  private final String id;
-
-  /**
    * Ctor.
    *
-   * @param doc XML
-   * @param id  State ID
+   * @param doc Xml document with migration
    */
-  public Names(final XML doc, final String id) {
+  public Ids(final XML doc) {
     this.xml = doc;
-    this.id = id;
-  }
-
-  /**
-   * Ctor.
-   *
-   * @param name File name
-   * @param id   State ID
-   * @throws Exception if something went wrong
-   */
-  public Names(final String name, final String id)
-    throws Exception {
-    this(
-      new XMLDocument(
-        new ResourceOf(
-          name
-        ).stream()
-      ),
-      id
-    );
   }
 
   @Override
   public List<String> value() {
     return this.xml.xpath(
-      "/states/changeState[@id='%s']/files/file/@path"
-        .formatted(
-          this.id
-        )
+      "/states/changeState/@id"
     );
   }
 }

--- a/src/test/java/io/github/eocqrs/cmig/meta/IdsTest.java
+++ b/src/test/java/io/github/eocqrs/cmig/meta/IdsTest.java
@@ -22,67 +22,32 @@
 
 package io.github.eocqrs.cmig.meta;
 
-import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.cactoos.io.ResourceOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 /**
- * File names of State.
- *
- * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * Test case for {@link Ids}.
  */
-public final class Names implements XpathList {
-
-  /**
-   * XML.
-   */
-  private final XML xml;
-
-  /**
-   * State ID.
-   */
-  private final String id;
-
-  /**
-   * Ctor.
-   *
-   * @param doc XML
-   * @param id  State ID
-   */
-  public Names(final XML doc, final String id) {
-    this.xml = doc;
-    this.id = id;
-  }
-
-  /**
-   * Ctor.
-   *
-   * @param name File name
-   * @param id   State ID
-   * @throws Exception if something went wrong
-   */
-  public Names(final String name, final String id)
-    throws Exception {
-    this(
+public final class IdsTest {
+  @Test
+  void readsAllIds() throws Exception {
+    final List<String> ids = new Ids(
       new XMLDocument(
-        new ResourceOf(
-          name
-        ).stream()
-      ),
-      id
-    );
-  }
-
-  @Override
-  public List<String> value() {
-    return this.xml.xpath(
-      "/states/changeState[@id='%s']/files/file/@path"
-        .formatted(
-          this.id
-        )
+        new ResourceOf("cmig/master.xml")
+          .stream()
+      )
+    ).value();
+    final List<String> expected = List.of("1", "2");
+    MatcherAssert.assertThat(
+      "%s contains all of %s"
+        .formatted(ids, expected),
+      ids,
+      Matchers.equalTo(expected)
     );
   }
 }


### PR DESCRIPTION
closes #53 

@h1alexbel take a look, please 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the `Ids` class to retrieve the IDs of change states from an XML document. It also includes a corresponding test case. 

### Detailed summary
- Added `Ids` class to retrieve change state IDs from XML document.
- Added corresponding test case `IdsTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->