### PR TITLE
prepared keyspace and table for CMIG checks

### DIFF
--- a/src/main/java/io/github/eocqrs/cmig/check/CmigKeyspace.java
+++ b/src/main/java/io/github/eocqrs/cmig/check/CmigKeyspace.java
@@ -1,0 +1,32 @@
+package io.github.eocqrs.cmig.check;
+
+import org.cactoos.Text;
+
+/**
+ * CMIG Check Keyspace.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
+public final class CmigKeyspace implements Text {
+
+  private final String dc;
+
+  public CmigKeyspace(final String datacenter) {
+    this.dc = datacenter;
+  }
+
+  @Override
+  public String asString() throws Exception {
+    return
+      """
+        CREATE KEYSPACE cmig 
+        WITH REPLICATION = {
+        'class': 'NetworkTopologyStrategy',
+        'datacenter': %s
+        };
+        """.formatted(
+        this.dc
+      );
+  }
+}

--- a/src/main/java/io/github/eocqrs/cmig/check/CmigKeyspace.java
+++ b/src/main/java/io/github/eocqrs/cmig/check/CmigKeyspace.java
@@ -1,3 +1,25 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.github.eocqrs.cmig.check;
 
 import org.cactoos.Text;
@@ -10,23 +32,26 @@ import org.cactoos.Text;
  */
 public final class CmigKeyspace implements Text {
 
+  /**
+   * Datacenter.
+   */
   private final String dc;
 
+  /**
+   * Ctor.
+   *
+   * @param datacenter Datacenter
+   */
   public CmigKeyspace(final String datacenter) {
     this.dc = datacenter;
   }
 
   @Override
   public String asString() throws Exception {
-    return
-      """
-        CREATE KEYSPACE cmig 
-        WITH REPLICATION = {
-        'class': 'NetworkTopologyStrategy',
-        'datacenter': %s
-        };
-        """.formatted(
-        this.dc
-      );
+    return ("CREATE KEYSPACE cmig\n"
+            + "WITH REPLICATION = {\n"
+            + "'class': 'NetworkTopologyStrategy',\n"
+            + "'datacenter1': %s\n"
+            + "};\n").formatted(this.dc);
   }
 }

--- a/src/main/java/io/github/eocqrs/cmig/check/StatesTable.java
+++ b/src/main/java/io/github/eocqrs/cmig/check/StatesTable.java
@@ -1,3 +1,25 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package io.github.eocqrs.cmig.check;
 
 import org.cactoos.Text;
@@ -12,15 +34,12 @@ public final class StatesTable implements Text {
 
   @Override
   public String asString() throws Exception {
-    return
-      """
-        CREATE TABLE cmig.states
-        (
-        id PRIMARY KEY,
-        author TEXT,
-        sha TEXT,
-        seen TIMESTAMP
-        );
-        """;
+    return "CREATE TABLE cmig.states\n"
+           + "(\n"
+           + "id INT PRIMARY KEY,\n"
+           + "author TEXT,\n"
+           + "sha TEXT,\n"
+           + "seen TIMESTAMP\n"
+           + ");\n";
   }
 }

--- a/src/main/java/io/github/eocqrs/cmig/check/StatesTable.java
+++ b/src/main/java/io/github/eocqrs/cmig/check/StatesTable.java
@@ -1,0 +1,26 @@
+package io.github.eocqrs.cmig.check;
+
+import org.cactoos.Text;
+
+/**
+ * States Table Specification.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
+public final class StatesTable implements Text {
+
+  @Override
+  public String asString() throws Exception {
+    return
+      """
+        CREATE TABLE cmig.states
+        (
+        id PRIMARY KEY,
+        author TEXT,
+        sha TEXT,
+        seen TIMESTAMP
+        );
+        """;
+  }
+}

--- a/src/main/java/io/github/eocqrs/cmig/check/package-info.java
+++ b/src/main/java/io/github/eocqrs/cmig/check/package-info.java
@@ -20,34 +20,10 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.cmig.check;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Test;
-
 /**
- * Test suite for {@link StatesTable}.
+ * Checks.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.0.0
  */
-final class StatesTableTest {
-
-  @Test
-  void readsTextInRightFormat() throws Exception {
-    MatcherAssert.assertThat(
-      "Text in right format",
-      new StatesTable().asString(),
-      new IsEqual<>(
-        "CREATE TABLE cmig.states\n"
-        + "(\n"
-        + "id INT PRIMARY KEY,\n"
-        + "author TEXT,\n"
-        + "sha TEXT,\n"
-        + "seen TIMESTAMP\n"
-        + ");\n"
-      )
-    );
-  }
-}
+package io.github.eocqrs.cmig.check;

--- a/src/main/java/io/github/eocqrs/cmig/session/Cql.java
+++ b/src/main/java/io/github/eocqrs/cmig/session/Cql.java
@@ -31,8 +31,9 @@ package io.github.eocqrs.cmig.session;
 public interface Cql {
 
   /**
-   * Apply Query.
+   * Applies Query.
    *
+   * @throws Exception if something went wrong.
    */
-  void apply();
+  void apply() throws Exception;
 }

--- a/src/main/java/io/github/eocqrs/cmig/session/InText.java
+++ b/src/main/java/io/github/eocqrs/cmig/session/InText.java
@@ -1,0 +1,43 @@
+package io.github.eocqrs.cmig.session;
+
+import org.cactoos.Text;
+
+/**
+ * CQL in plain text.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
+public final class InText implements Cql {
+
+  /**
+   * Text CQL query.
+   */
+  private final Text text;
+
+  /**
+   * Cassandra.
+   */
+  private final Cassandra cassandra;
+
+  /**
+   * Ctor.
+   *
+   * @param txt    Text
+   * @param cssndr Cassandra
+   */
+  public InText(
+    final Text txt,
+    final Cassandra cssndr
+  ) {
+    this.text = txt;
+    this.cassandra = cssndr;
+  }
+
+  @Override
+  public void apply() throws Exception {
+    this.cassandra.value().execute(
+      this.text.asString()
+    );
+  }
+}

--- a/src/main/java/io/github/eocqrs/cmig/sha/Sha.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/Sha.java
@@ -23,6 +23,7 @@
 package io.github.eocqrs.cmig.sha;
 
 import io.github.eocqrs.cmig.meta.Names;
+import lombok.SneakyThrows;
 import org.cactoos.Text;
 import org.cactoos.bytes.Sha256DigestOf;
 import org.cactoos.io.InputOf;
@@ -70,8 +71,9 @@ public final class Sha implements Text {
     this.cmig = cmg;
   }
 
+  @SneakyThrows
   @Override
-  public String asString() throws Exception {
+  public String asString() {
     final List<String> contents = new StateChanges(
       new Names(
         this.master,

--- a/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
+++ b/src/main/java/io/github/eocqrs/cmig/sha/StateChanges.java
@@ -38,7 +38,7 @@ public final class StateChanges implements Scalar<List<String>> {
   /**
    * XPATH lists.
    */
-  private final XpathList list;
+  private final XpathList xpath;
 
   /**
    * CMIG directory.
@@ -52,13 +52,13 @@ public final class StateChanges implements Scalar<List<String>> {
    * @param cmg CMIG directory
    */
   public StateChanges(final XpathList lst, final String cmg) {
-    this.list = lst;
+    this.xpath = lst;
     this.cmig = cmg;
   }
 
   @Override
   public List<String> value() throws Exception {
-    return this.list.value()
+    return this.xpath.value()
       .stream()
       .map(
         name ->

--- a/src/test/java/io/github/eocqrs/cmig/check/CmigKeyspaceTest.java
+++ b/src/test/java/io/github/eocqrs/cmig/check/CmigKeyspaceTest.java
@@ -41,13 +41,11 @@ final class CmigKeyspaceTest {
       new CmigKeyspace("1")
         .asString(),
       new IsEqual<>(
-        """
-          CREATE KEYSPACE cmig 
-          WITH REPLICATION = {
-          'class': 'NetworkTopologyStrategy',
-          'datacenter': 1
-          };
-          """
+        "CREATE KEYSPACE cmig\n"
+        + "WITH REPLICATION = {\n"
+        + "'class': 'NetworkTopologyStrategy',\n"
+        + "'datacenter1': 1\n"
+        + "};\n"
       )
     );
   }

--- a/src/test/java/io/github/eocqrs/cmig/check/CmigKeyspaceTest.java
+++ b/src/test/java/io/github/eocqrs/cmig/check/CmigKeyspaceTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.cmig.check;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for {@link CmigKeyspace}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
+final class CmigKeyspaceTest {
+
+  @Test
+  void readsTextInRightFormat() throws Exception {
+    MatcherAssert.assertThat(
+      "Text in right format",
+      new CmigKeyspace("1")
+        .asString(),
+      new IsEqual<>(
+        """
+          CREATE KEYSPACE cmig 
+          WITH REPLICATION = {
+          'class': 'NetworkTopologyStrategy',
+          'datacenter': 1
+          };
+          """
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/cmig/check/StatesTableTest.java
+++ b/src/test/java/io/github/eocqrs/cmig/check/StatesTableTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.cmig.check;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for {@link StatesTable}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.0.0
+ */
+final class StatesTableTest {
+
+  @Test
+  void readsTextInRightFormat() throws Exception {
+    MatcherAssert.assertThat(
+      "Text in right format",
+      new StatesTable().asString(),
+      new IsEqual<>(
+        """
+          CREATE TABLE cmig.states
+          (
+          id PRIMARY KEY,
+          author TEXT,
+          sha TEXT,
+          seen TIMESTAMP
+          );
+          """
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/cmig/session/InTextTest.java
+++ b/src/test/java/io/github/eocqrs/cmig/session/InTextTest.java
@@ -20,34 +20,34 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.cmig.check;
+package io.github.eocqrs.cmig.session;
 
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Test suite for {@link StatesTable}.
+ * Test suite for {@link InText}.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.0.0
  */
-final class StatesTableTest {
+@ExtendWith(MockitoExtension.class)
+final class InTextTest {
 
   @Test
-  void readsTextInRightFormat() throws Exception {
+  void createsWithMockCassandra(@Mock final Cassandra mock) {
     MatcherAssert.assertThat(
-      "Text in right format",
-      new StatesTable().asString(),
-      new IsEqual<>(
-        "CREATE TABLE cmig.states\n"
-        + "(\n"
-        + "id INT PRIMARY KEY,\n"
-        + "author TEXT,\n"
-        + "sha TEXT,\n"
-        + "seen TIMESTAMP\n"
-        + ");\n"
-      )
+      "Creates cql from text",
+      new InText(
+        new TextOf("SELECT * FROM cmig.states"),
+        mock
+      ),
+      Matchers.notNullValue()
     );
   }
 }


### PR DESCRIPTION
@l3r8yJ take a look, please
closes #55

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making changes to the codebase related to the Cmig session, Sha, StateChanges, InText, and check packages. 

### Detailed summary
- Renamed the method `apply` in the `Cql` interface to `applies` and added an `Exception` to its signature.
- Added the `@SneakyThrows` annotation to the `asString` method in the `Sha` class.
- Renamed the field `list` to `xpath` in the `StateChanges` class.
- Added the `InText` class to the `session` package.
- Added the `package-info.java` file to the `check` package.
- Added the `StatesTable` and `CmigKeyspace` classes to the `check` package.
- Added the test classes `StatesTableTest` and `CmigKeyspaceTest` to the `check` package.
- Updated the `CmigKeyspace` class to implement the `Text` interface.
- Added the test class `InTextTest` to the `session` package.

> The following files were skipped due to too many changes: `src/test/java/io/github/eocqrs/cmig/session/InTextTest.java`, `src/test/java/it/CmigKeyspaceIT.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->