### PR TITLE
docs, skip ITs on deploy

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -17,4 +17,4 @@ release:
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}"
     git commit -am "${tag}"
-    mvn clean deploy -Prelease --errors --settings ../settings.xml
+    mvn clean deploy -DskipITs -Prelease --errors --settings ../settings.xml

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ Decompose files for better traceability.
 In Java, all you need is to create Cassandra and Master objects:
 ```java
 final Cassandra cassandra = new Simple("localhost", 9042);
-final String sha = new Master("master.xml", cassandra).value();
+final String sha = new Preload(
+  new Master("cmig/master.xml", cassandra),
+  cassandra, "1" // datacenter of cmig keyspace
+).value();
 ```
 
 ## How to Contribute


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the Maven command in the `.rultor.yml` file and modifying the code in the `README.md` file to include a new parameter in the `Preload` constructor.

### Detailed summary
- Updated Maven command in `.rultor.yml` to include the `-DskipITs` flag.
- Modified code in `README.md` to include a new parameter in the `Preload` constructor.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->